### PR TITLE
Add "examples" to allowed Meta

### DIFF
--- a/src/builder.ts
+++ b/src/builder.ts
@@ -65,7 +65,7 @@ export type AnySchemaBuilder =
 
 export type MetaObject = PickMany<
   BaseSchema,
-  ["title", "description", "deprecated", "$id", "$async", "$ref", "$schema"]
+  ["title", "description", "deprecated", "examples", "$id", "$async", "$ref", "$schema"]
 >;
 
 export type SafeParseResult<T> =


### PR DESCRIPTION
Based on the [ajv docs](https://ajv.js.org/json-schema.html#metadata-keywords) it looks like `examples`, which already exists on `BaseSchema`, should be allowable as a `meta` property. I don't see any other references to `examples` anywhere in the package – please lmk if I've missed something and I should just use some other means of setting `examples`